### PR TITLE
chore: Update rclrs_example_msgs version

### DIFF
--- a/rclrs/message_demo/Cargo.toml
+++ b/rclrs/message_demo/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/message_demo.rs"
 anyhow = {version = "1", features = ["backtrace"]}
 rclrs = "0.5"
 rosidl_runtime_rs = "0.4"
-rclrs_example_msgs = { version = "0.4", features = ["serde"] }
+rclrs_example_msgs = { version = "0.5", features = ["serde"] }
 serde_json = "1.0"
 
 # This specific version is compatible with Rust 1.75


### PR DESCRIPTION
Bump the version of `rclrs_example_msgs` to 0.5.0 to fix a build issue with the `examples` repo.

```
--- stderr: examples_rclrs_message_demo                                                                  
error: failed to select a version for the requirement `rclrs_example_msgs = "^0.4"`
candidate versions found which didn't match: 0.5.0
location searched: crates.io index
required by package `examples_rclrs_message_demo v0.5.0 (/home/sam/rust_ws/src/ros2-rust/examples/rclrs/message_demo)`
perhaps a crate was updated and forgotten to be re-vendored?
---
```