### PR TITLE
chore: bump rclrs dependency version to 0.6 and rosidl_runtime_rs to 0.5

### DIFF
--- a/rclrs/logging_demo/Cargo.toml
+++ b/rclrs/logging_demo/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.5.0"
 edition = "2021"
 
 [dependencies]
-rclrs = "0.5"
+rclrs = "0.6"
 example_interfaces = "*"

--- a/rclrs/message_demo/Cargo.toml
+++ b/rclrs/message_demo/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/message_demo.rs"
 
 [dependencies]
 anyhow = {version = "1", features = ["backtrace"]}
-rclrs = "0.5"
-rosidl_runtime_rs = "0.4"
+rclrs = "0.6"
+rosidl_runtime_rs = "0.5"
 rclrs_example_msgs = { version = "0.5", features = ["serde"] }
 serde_json = "1.0"
 

--- a/rclrs/minimal_client_service/Cargo.toml
+++ b/rclrs/minimal_client_service/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/minimal_service.rs"
 [dependencies]
 anyhow = {version = "1", features = ["backtrace"]}
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
-rclrs = "0.5"
-rosidl_runtime_rs = "0.4"
+rclrs = "0.6"
+rosidl_runtime_rs = "0.5"
 example_interfaces = "*"
 
 # This specific version is compatible with Rust 1.75

--- a/rclrs/minimal_pub_sub/Cargo.toml
+++ b/rclrs/minimal_pub_sub/Cargo.toml
@@ -27,8 +27,8 @@ path = "src/zero_copy_publisher.rs"
 
 [dependencies]
 anyhow = {version = "1", features = ["backtrace"]}
-rclrs = "0.5"
-rosidl_runtime_rs = "0.4"
+rclrs = "0.6"
+rosidl_runtime_rs = "0.5"
 example_interfaces = "*"
 
 # This specific version is compatible with Rust 1.75

--- a/rclrs/parameter_demo/Cargo.toml
+++ b/rclrs/parameter_demo/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.5.0"
 edition = "2021"
 
 [dependencies]
-rclrs = "0.5"
+rclrs = "0.6"
 example_interfaces = "*"

--- a/rclrs/worker_demo/Cargo.toml
+++ b/rclrs/worker_demo/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.5.0"
 edition = "2021"
 
 [dependencies]
-rclrs = "0.5"
+rclrs = "0.6"
 example_interfaces = "*"


### PR DESCRIPTION
Fixes #13 