### PR TITLE
Fix example names, address TODO in worker demo

### DIFF
--- a/rclrs/logging_demo/Cargo.toml
+++ b/rclrs/logging_demo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples_logging_demo"
+name = "examples_rclrs_logging_demo"
 version = "0.5.0"
 edition = "2021"
 

--- a/rclrs/logging_demo/package.xml
+++ b/rclrs/logging_demo/package.xml
@@ -3,12 +3,12 @@
    href="http://download.ros.org/schema/package_format3.xsd"
    schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>examples_logging_demo</name>
+  <name>examples_rclrs_logging_demo</name>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>
   <!-- This project is not military-sponsored, Jacob's employment contract just requires him to use this email address -->
   <maintainer email="jacob.a.hassold.civ@army.mil">Jacob Hassold</maintainer>
   <version>0.5.0</version>
-  <description>Package containing an example of how to use a worker in rclrs.</description>
+  <description>Package containing an example of how to use logging rclrs.</description>
   <license>Apache License 2.0</license>
 
   <depend>rclrs</depend>

--- a/rclrs/parameter_demo/Cargo.toml
+++ b/rclrs/parameter_demo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples_parameter_demo"
+name = "examples_rclrs_parameter_demo"
 version = "0.5.0"
 edition = "2021"
 

--- a/rclrs/parameter_demo/package.xml
+++ b/rclrs/parameter_demo/package.xml
@@ -3,12 +3,12 @@
    href="http://download.ros.org/schema/package_format3.xsd"
    schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>examples_parameter_demo</name>
+  <name>examples_rclrs_parameter_demo</name>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>
   <!-- This project is not military-sponsored, Jacob's employment contract just requires him to use this email address -->
   <maintainer email="jacob.a.hassold.civ@army.mil">Jacob Hassold</maintainer>
   <version>0.5.0</version>
-  <description>Package containing an example of how to use a worker in rclrs.</description>
+  <description>Package containing an example of how to use parameters rclrs.</description>
   <license>Apache License 2.0</license>
 
   <depend>rclrs</depend>

--- a/rclrs/worker_demo/Cargo.toml
+++ b/rclrs/worker_demo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples_worker_demo"
+name = "examples_rclrs_worker_demo"
 version = "0.5.0"
 edition = "2021"
 

--- a/rclrs/worker_demo/package.xml
+++ b/rclrs/worker_demo/package.xml
@@ -3,7 +3,7 @@
    href="http://download.ros.org/schema/package_format3.xsd"
    schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>examples_worker_demo</name>
+  <name>examples_rclrs_worker_demo</name>
   <maintainer email="esteve@apache.org">Esteve Fernandez</maintainer>
   <!-- This project is not military-sponsored, Jacob's employment contract just requires him to use this email address -->
   <maintainer email="jacob.a.hassold.civ@army.mil">Jacob Hassold</maintainer>

--- a/rclrs/worker_demo/src/main.rs
+++ b/rclrs/worker_demo/src/main.rs
@@ -1,5 +1,5 @@
 use rclrs::*;
-use std::sync::Arc;
+use std::time::Duration;
 
 fn main() -> Result<(), RclrsError> {
     let mut executor = Context::default_from_env()?.create_basic_executor();
@@ -15,27 +15,18 @@ fn main() -> Result<(), RclrsError> {
         },
     )?;
 
-    // // Use this timer-based implementation when timers are available instead
-    // // of using std::thread::spawn.
-    // let _timer = worker.create_timer_repeating(
-    //     Duration::from_secs(1),
-    //     move |data: &mut String| {
-    //         let msg = example_interfaces::msg::String {
-    //             data: data.clone()
-    //         };
+    // Use this timer-based implementation when timers are available instead
+    // of using std::thread::spawn.
+    let _timer = worker.create_timer_repeating(
+        Duration::from_secs(1),
+        move |data: &mut String| {
+            let msg = example_interfaces::msg::String {
+                data: data.clone()
+            };
 
-    //         publisher.publish(msg).ok();
-    //     }
-    // )?;
-
-    std::thread::spawn(move || loop {
-        std::thread::sleep(std::time::Duration::from_secs(1));
-        let publisher = Arc::clone(&publisher);
-        let _ = worker.run(move |data: &mut String| {
-            let msg = example_interfaces::msg::String { data: data.clone() };
-            publisher.publish(msg).unwrap();
-        });
-    });
+            publisher.publish(msg).ok();
+        }
+    )?;
 
     println!(
         "Beginning repeater... \n >> \


### PR DESCRIPTION
I noticed that some of the new examples didn't follow the example naming convention (which should include the client library name in the package name), descriptions were also incorrect because they were copy pasted.
Finally, there was a commented code snippet with a TODO to uncomment it when the timer PR was merged and released, which happened so I did that as well.